### PR TITLE
Fix for plugin issues when working with new config

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -74,7 +74,7 @@ class FlareSolverrExtension extends Minz_Extension
     {
 
 		if(version_compare(FRESHRSS_VERSION, "1.26.3",">")){
-			return Minz_Url::display('/api/misc.php/'.$this->getName().'?feed=', 'html', true);
+			return Minz_Url::display('/api/misc.php/'.rawurlencode($this->getName()).'?feed=', 'html', true);
 		}else{
 			return Minz_Url::display('/api/cloudsolver.php?feed=', 'html', true);
 

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
 	"name": "FreshRss FlareSolverr",
 	"author": "James Ravenscroft",
 	"description": "Use a Flaresolverr instance to bypass cloudflare security checks",
-	"version": 0.4,
+	"version": "0.4.1",
 	"entrypoint": "FlareSolverr",
 	"type": "system"
 }


### PR DESCRIPTION
Should fix #26 by using the new `systemConfig()` config accessor instead of the deprecated `system_config` direct access. 

Also tidied up the feed URL in the config pane by using `rawurlencode()` to swap spaces in the extension name for %20.

Split out curl connectivity errorrs from JSON parsing errors to make debugging slightly easier