### PR TITLE
Fix/config timeout bug

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -86,7 +86,7 @@ function fetch_feed($feed) {
 	];
 
 	// set global timeout based on config or default to 60 seconds
-	$globalTimeout = isset(FreshRSS_Context::systemConf()->flaresolver_maxTimeout) ? intval(FreshRSS_Context::systemConf()->flaresolver_maxTimeout) : 60000;
+	$globalTimeout = FreshRSS_Context::systemConf()->hasParam('flaresolver_maxTimeout') ? intval(FreshRSS_Context::systemConf()->flaresolver_maxTimeout) : 60000;
 
 	// if maxTimeout param is set then use it instead of global one as long as it is less than global one.
 	$maxTimeout = isset($_GET['maxTimeout']) ? min(array(intval($_GET['maxTimeout']), $globalTimeout)) : $globalTimeout;

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
 	"name": "FreshRss FlareSolverr",
 	"author": "James Ravenscroft",
 	"description": "Use a Flaresolverr instance to bypass cloudflare security checks",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"entrypoint": "FlareSolverr",
 	"type": "system"
 }


### PR DESCRIPTION
Fixes #29 - identified and eliminated incorrect checking for a global timeout value which meant that the extension always fell back to 60 seconds.