### PR TITLE
Add `raw` parameter, fix XSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ If turning on the plugin gives an and you are using FreshRSS V1.26.3 or older, y
 
 If you're running FreshRSS V1.26.4 or later and the plugin prepend url has `/api/misc.php` in it, you might not have turned on API access. Go to via Administration -> Authentication menu and tick Allow API access.
 
-### Problem Rendering Feed
+### Problem Fetching Feed
 
-If you are having trouble rendering the feed, you can append `&debug=1` to the URL to see some additional information about the Flaresolverr endpoint and exactly what is being returned by the browser. 
+If you are having trouble fetching the feed, you can append `&raw=1` to the URL to force HTML support for example when using XPath scraping.
 
 ## Contributing
 

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
 	"name": "FreshRss FlareSolverr",
 	"author": "James Ravenscroft",
 	"description": "Use a Flaresolverr instance to bypass cloudflare security checks",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"entrypoint": "FlareSolverr",
 	"type": "system"
 }


### PR DESCRIPTION
I wanted a way to use XPath scraping with HTML, but the URL didn't work without the `debug` parameter.
Then I also realized the retrieved contents are unsanitized and sent without a CSP header, so I made some improvements.

edit: do I update the README regarding `debug=1` too, or do something else?